### PR TITLE
fix: Increase http timeout

### DIFF
--- a/parma_mining/affinity/analytics_client.py
+++ b/parma_mining/affinity/analytics_client.py
@@ -34,7 +34,7 @@ class AnalyticsClient:
             "Authorization": f"Bearer {token}",
         }
 
-        response = httpx.post(api_endpoint, json=data, headers=headers)
+        response = httpx.post(api_endpoint, json=data, headers=headers, timeout=120)
 
         if response.status_code in [200, 201]:
             return response.json()

--- a/parma_mining/affinity/client.py
+++ b/parma_mining/affinity/client.py
@@ -23,6 +23,7 @@ class AffinityClient:
             auth=BasicAuth("", self.api_key),
             headers={"Content-Type": "application/json"},
             params=params,
+            timeout=30,
         )
 
     def get_all_companies(self) -> list[OrganizationModel]:


### PR DESCRIPTION
# Motivation

httpx's default timeout of 5 seconds is not enough for sending a request to analytics.

<img width="630" alt="image" src="https://github.com/la-famiglia-jst2324/parma-mining-affinity/assets/48245934/5b81ba99-c21d-4442-8cd9-c260fa13f596">

<img width="1006" alt="image" src="https://github.com/la-famiglia-jst2324/parma-mining-affinity/assets/48245934/11cb4ce3-55b8-4d9e-abcb-52baaebd9a50">


# Changes

- timeout increased for both affinity client and analytics client

# Checklist

- [x] added myself as assignee
- [x] correct reviewers
- [x] descriptive PR title using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] description explains the motivation and details of the changes
- [x] tests cover my changes
- [x] my functions are fully typed
- [x] documentation is updated
- [x] CI is green
- [x] breaking changes are discussed with the team and documented in the PR title `!` (e.g. `feat!: Update endpoint`)
